### PR TITLE
Fix null value return by the getFlavor() method in release

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ void main() async {
 
 For a complete example of using Flavor Getter, please refer to the example directory of this plugin.
 
+## Troubleshooting
+Problems with Proguard
+When Proguard is enabled (which it is by default for Android release builds), it can rename the BuildConfig Java class in the minification process and prevent the library from referencing it. To avoid this, add a rule in android/app/proguard-rules.pro:
+
+-keep class com.yourNewPackage.BuildConfig { *; }
+
+com.yourNewPackage should match the package value in your app/src/main/AndroidManifest.xml file.
+
 ## Issues and Contributions
 
 Please report any issues or bugs you encounter by opening an issue on the GitHub repository. Contributions are also welcome via pull requests.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For a complete example of using Flavor Getter, please refer to the example direc
 Problems with Proguard
 When Proguard is enabled (which it is by default for Android release builds), it can rename the BuildConfig Java class in the minification process and prevent the library from referencing it. To avoid this, add a rule in android/app/proguard-rules.pro:
 
--keep class com.yourNewPackage.BuildConfig { *; }
+`-keep class com.yourNewPackage.BuildConfig { *; }`
 
 com.yourNewPackage should match the package value in your app/src/main/AndroidManifest.xml file.
 

--- a/example/android/app/proguard-rules.pro
+++ b/example/android/app/proguard-rules.pro
@@ -1,0 +1,23 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile
+
+-keep class com.thepinkchannel.flavor_getter_example.BuildConfig { *; }


### PR DESCRIPTION
Fix null value return by the getFlavor() method by adding a proguard rule to keep the BuildConfig file when obfuscating the code